### PR TITLE
Add stats info for Vars in CTEs.

### DIFF
--- a/src/backend/utils/adt/selfuncs.c
+++ b/src/backend/utils/adt/selfuncs.c
@@ -5343,7 +5343,10 @@ get_variable_numdistinct(VariableStatData *vardata, bool *isdefault)
 					stadistinct = getgpsegmentCount();
 					break;
 				default:
-					stadistinct = 0.0;	/* means "unknown" */
+					if (vardata->rel->rtekind == RTE_CTE)
+						stadistinct = -1.0;
+					else
+						stadistinct = 0.0;	/* means "unknown" */
 					break;
 			}
 		}


### PR DESCRIPTION
In the function selfuncs.c:eqjoinsel  it uses the number of the distinct values of

the two join variables to estimate join size, and in the function  selfuncs.c:get_variable_numdistinct  return a default value DEFAULT_NUM_DISTINCT 

(200 in Postgres and 1000 in Greenplum),  with the default value, you can never expect a good plan.


A mini-repro is:
```sql
postgres=# create table t(x int, y int);
NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
CREATE TABLE
postgres=# insert into t select i, i from generate_series(1, 100000) i;
INSERT 0 100000
postgres=# anaylze;
postgres=#  explain analyze with cte(x,y,z) as  (select *, random() from t) select * from cte m, cte n where m.x=n.y ;
```
Before the patch, we got a plan with bad join size estimation:
```sql
                                                                     QUERY PLAN                                                                      
-----------------------------------------------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=870.33..307629.56 rows=10000000 width=32) (actual time=25.434..118.804 rows=100000 loops=1)
   ->  Hash Join  (cost=870.33..174296.22 rows=3333333 width=32) (actual time=24.784..85.076 rows=33462 loops=1)
         Hash Cond: (t.y = t_1.x)
         Extra Text: (seg0)   Hash chain length 1.0 avg, 3 max, using 32439 of 524288 buckets.
         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1120.33 rows=33333 width=16) (actual time=0.072..18.581 rows=33462 loops=1)
               Hash Key: t.y
               ->  Seq Scan on t  (cost=0.00..453.67 rows=33333 width=16) (actual time=0.057..11.490 rows=33462 loops=1)
         ->  Hash  (cost=453.67..453.67 rows=33333 width=16) (actual time=24.105..24.106 rows=33462 loops=1)
               Buckets: 524288  Batches: 1  Memory Usage: 5665kB
               ->  Seq Scan on t t_1  (cost=0.00..453.67 rows=33333 width=16) (actual time=0.037..11.040 rows=33462 loops=1)
 Optimizer: Postgres query optimizer
 Planning Time: 0.667 ms
```

After the patch applied, we got:
```sql
                                                                     QUERY PLAN                                                                      
-----------------------------------------------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=870.33..3782.33 rows=100000 width=32) (actual time=28.715..88.846 rows=100000 loops=1)
   ->  Hash Join  (cost=870.33..2449.00 rows=33333 width=32) (actual time=27.515..70.070 rows=33462 loops=1)
         Hash Cond: (t.y = t_1.x)
         Extra Text: (seg0)   Hash chain length 1.0 avg, 3 max, using 32439 of 524288 buckets.
         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1120.33 rows=33333 width=16) (actual time=0.074..16.497 rows=33462 loops=1)
               Hash Key: t.y
               ->  Seq Scan on t  (cost=0.00..453.67 rows=33333 width=16) (actual time=0.132..10.108 rows=33462 loops=1)
         ->  Hash  (cost=453.67..453.67 rows=33333 width=16) (actual time=25.522..25.523 rows=33462 loops=1)
               Buckets: 524288  Batches: 1  Memory Usage: 5665kB
               ->  Seq Scan on t t_1  (cost=0.00..453.67 rows=33333 width=16) (actual time=0.072..11.546 rows=33462 loops=1)
 Optimizer: Postgres query optimizer
 Planning Time: 2.570 ms
```

The join size estimation on the upper of CTE scans became much accurate.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
